### PR TITLE
Import test results even if error occurs

### DIFF
--- a/Package/Jaahas.Cake.Extensions.nuspec
+++ b/Package/Jaahas.Cake.Extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Jaahas.Cake.Extensions</id>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <title></title>
     <authors>Graham Watts</authors>
     <owners></owners>

--- a/Package/content/build-utilities.cake
+++ b/Package/content/build-utilities.cake
@@ -203,11 +203,14 @@ private void ConfigureTasks() {
                     };
                 }
 
-                DotNetTest(state.SolutionName, testSettings);
-
-                if (testResultsPrefix != null) {
-                    foreach (var testResultsFile in GetFiles($"./**/TestResults/{testResultsPrefix}*.trx")) {
-                        ImportTestResults(BuildSystem, "mstest", testResultsFile);
+                try {
+                    DotNetTest(state.SolutionName, testSettings);
+                }
+                finally {
+                    if (testResultsPrefix != null) {
+                        foreach (var testResultsFile in GetFiles($"./**/TestResults/{testResultsPrefix}*.trx")) {
+                            ImportTestResults(BuildSystem, "mstest", testResultsFile);
+                        }
                     }
                 }
             }),


### PR DESCRIPTION
Adds a try..finally around the call to `DotNetTest` to ensure that test results are imported even if `DotNetTest` exits with a non-good status code.