### PR TITLE
Don't try..catch RunTarget call

### DIFF
--- a/Package/Jaahas.Cake.Extensions.nuspec
+++ b/Package/Jaahas.Cake.Extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Jaahas.Cake.Extensions</id>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
     <title></title>
     <authors>Graham Watts</authors>
     <owners></owners>

--- a/Package/content/build-utilities.cake
+++ b/Package/content/build-utilities.cake
@@ -32,13 +32,7 @@ public string GetTarget() {
 
 // Runs the specified target.
 public void Run(string target = null) {
-    try {
-        RunTarget(target ?? GetTarget());
-    }
-    catch (Exception e) {
-        WriteErrorMessage(BuildSystem, null, e);
-        throw;
-    }
+    RunTarget(target ?? GetTarget());
 }
 
 


### PR DESCRIPTION
Putting a try..catch around the call to `RunTarget` and logging the error message just puts extra cruft in the console as the stack trace lists internal Cake calls rather than anything helpful from the external call that actually failed.