### PR TITLE
Install latest stable version of CycloneDX

### DIFF
--- a/Package/Jaahas.Cake.Extensions.nuspec
+++ b/Package/Jaahas.Cake.Extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Jaahas.Cake.Extensions</id>
-    <version>1.6.2</version>
+    <version>1.7.0</version>
     <title></title>
     <authors>Graham Watts</authors>
     <owners></owners>

--- a/Package/content/build-utilities.cake
+++ b/Package/content/build-utilities.cake
@@ -3,7 +3,7 @@ using Spectre.Console;
 #addin nuget:?package=Cake.Git&version=3.0.0
 #addin nuget:?package=Cake.Json&version=7.0.1
 
-#tool dotnet:?package=CycloneDX&version=2.7.0
+#tool dotnet:?package=CycloneDX
 
 #load "build-state.cake"
 #load "task-definitions.cake"


### PR DESCRIPTION
`build-utilities.cake` will now always install the latest stable version of CycloneDX for SBOM generation.