### PR TITLE
v2.0 updates

### DIFF
--- a/Example/.config/dotnet-tools.json
+++ b/Example/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
       "cake.tool": {
-        "version": "3.0.0",
+        "version": "4.0.0",
         "commands": [
           "dotnet-cake"
         ]

--- a/Package/Jaahas.Cake.Extensions.nuspec
+++ b/Package/Jaahas.Cake.Extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Jaahas.Cake.Extensions</id>
-    <version>1.7.0</version>
+    <version>2.0.0</version>
     <title></title>
     <authors>Graham Watts</authors>
     <owners></owners>
@@ -10,7 +10,7 @@
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/wazzamatazz/cake-recipes</projectUrl>
     <description>Extensions for the Cake build system.</description>
-    <copyright>Copyright © 2021-2023 Graham Watts</copyright>
+    <copyright>Copyright © 2021-2024 Graham Watts</copyright>
     <tags>Cake Script Build</tags>
   </metadata>
 </package>


### PR DESCRIPTION
This PR updates the dependencies used in build scripts and makes some breaking changes:

* Updates Cake.Git reference to v4.0. This indirectly updates the minimum required Cake version to v4.0.
* Removes Cake.Json reference. The build utilities now use System.Text.Json for parsing build version JSON files.
* Updates CycloneDX tool version to 3.0.6
* Modifies build numbers and versions so that they don't include the build counter unless it has been explicitly set via the `--build-counter` argument.