### PR TITLE
Suppress dependencies when building package

### DIFF
--- a/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
+++ b/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <NoWarn>NU5128;$(NoWarn)</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <Description>Extensions for the Cake build system.</Description>
     <Version>2.0.1</Version>
     <Authors>Graham Watts</Authors>
@@ -11,8 +18,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Cake Script Build</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <NoWarn>NU5128;$(NoWarn)</NoWarn>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/wazzamatazz/cake-recipes</RepositoryUrl>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
Ensures that the `<dependencies>` element in the package metadata is empty