### PR TITLE
BOM licence validation error

### DIFF
--- a/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
+++ b/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <Description>Extensions for the Cake build system.</Description>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <Authors>Graham Watts</Authors>
     <CopyrightStartYear>2021</CopyrightStartYear>
     <PackageProjectUrl>https://github.com/wazzamatazz/cake-recipes</PackageProjectUrl>

--- a/src/Jaahas.Cake.Extensions/content/build-utilities.cake
+++ b/src/Jaahas.Cake.Extensions/content/build-utilities.cake
@@ -4,7 +4,7 @@ using Spectre.Console;
 
 #addin nuget:?package=Cake.Git&version=4.0.0
 
-#tool dotnet:?package=CycloneDX&version=3.0.6
+#tool dotnet:?package=CycloneDX&version=3.0.8
 
 #load "build-state.cake"
 #load "task-definitions.cake"


### PR DESCRIPTION
This PR updates the version of the CycloneDX tool used when generating a bill of materials to fix an issue where referencing packages that specify multiple licences (such as CsvHelper) would result in an invalid BOM being generated.