### PR TITLE
Add Publish and PublishContainer targets

### DIFF
--- a/samples/ExampleApp/ExampleApp.csproj
+++ b/samples/ExampleApp/ExampleApp.csproj
@@ -2,13 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/samples/build.cake
+++ b/samples/build.cake
@@ -15,7 +15,7 @@ const string VersionFile = "./version.json";
 // --target=<TARGET>
 //   The Cake target to run. 
 //     Default: Test
-//     Possible Values: Clean, Restore, Build, Test, Pack, BillOfMaterials
+//     Possible Values: Clean, Restore, Build, Test, Pack, Publish, PublishContainer, BillOfMaterials
 //
 // --configuration=<CONFIGURATION>
 //   The MSBuild configuration to use. 
@@ -44,6 +44,18 @@ const string VersionFile = "./version.json";
 //   Additional build metadata that will be included in the informational version number generated 
 //   for compiled assemblies.
 //
+// --container-registry=<REGISTRY>
+//   The container registry to use when the PublishContainer target is run.
+//     Default: Local Docker or Podman daemon
+//
+// --container-os=<OS>
+//   The container operating system to use when the PublishContainer target is run.
+//     Default: linux
+//
+// --container-arch=<ARCHITECTURE>
+//   The container processor architecture to use when the PublishContainer target is run.
+//     Default: x64
+//
 // --property=<PROPERTY>
 //   Specifies an additional property to pass to MSBuild during Build and Pack targets. The value
 //   must be specified using a '<NAME>=<VALUE>' format e.g. --property="NoWarn=CS1591". This 
@@ -61,11 +73,12 @@ const string VersionFile = "./version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load ../Package/content/build-state.cake
-#load ../Package/content/build-utilities.cake
+#load ../src/Jaahas.Cake.Extensions/content/build-utilities.cake
 
 // Bootstrap build context and tasks.
-Bootstrap(DefaultSolutionFile, VersionFile);
+Bootstrap(DefaultSolutionFile, VersionFile, containerProjects: new [] {
+    "ExampleApp"
+});
 
 Task("ErrorTest")
     .Does<BuildState>(state => {

--- a/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
+++ b/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <Description>Extensions for the Cake build system.</Description>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
     <Authors>Graham Watts</Authors>
     <CopyrightStartYear>2021</CopyrightStartYear>
     <PackageProjectUrl>https://github.com/wazzamatazz/cake-recipes</PackageProjectUrl>

--- a/src/Jaahas.Cake.Extensions/README.md
+++ b/src/Jaahas.Cake.Extensions/README.md
@@ -21,7 +21,7 @@ Update your `build.cake` file as follows:
 const string DefaultSolutionFile = "./MySolution.sln";
 const string VersionFile = "./version.json";
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=2.0.1
+#load nuget:?package=Jaahas.Cake.Extensions&version=2.1.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);
@@ -29,5 +29,40 @@ Bootstrap(DefaultSolutionFile, VersionFile);
 // Run the specified target.
 Run();
 ```
+
+# Targets
+
+The recipe supports the following targets (specified by the `--target` parameter passed to Cake):
+
+| Target | Description | Default Build Configuration |
+| ------ | ----------- | --------------------------- |
+| `Clean` | Cleans the `obj`, `bin`, `artifacts` and `TestResults` folders for the repository. | Debug |
+| `Restore` | Restores NuGet packages for the solution. | Debug |
+| `Build` | Builds the solution. | Debug |
+| `Test` | Runs unit tests for the solution. | Debug |
+| `Pack` | Creates NuGet packages for the solution. | Release |
+| `Publish` | Publishes any solution projects that define one or more `.pubxml` publish profiles under the project folder. | Release |
+| `PublishContainer` | Publishes container images for any solution projects that are registered as container projects. [See below](#publishing-container-images) for more information. | Release |
+| `BillOfMaterials` | Generates a Software Bill of Materials (SBOM) for the solution using [CycloneDX](https://github.com/CycloneDX/cyclonedx-dotnet). | Release |
+
+The Default Build Configuration specifies the default MSBuild configuration used when specifying a target and the `--configuration` parameter is not specified.
+
+# Publishing Container Images
+
+If your solution contains one or more projects that you want to publish container images for when the `PublishContainer` target is specified, you must include the names of the projects (without the project file extension) when calling the `Bootstrap()` method in your `build.cake` file. For example:
+
+```cake
+Bootstrap(
+    DefaultSolutionFile, 
+    VersionFile, 
+    containerProjects: new [] {
+        "MyFirstContainerProject",
+        "MySecondContainerProject"
+    });
+```
+
+Note that projects that publish container images can also define a `.pubxml` publish profile for publishing the image via the `Publish` target instead.
+
+# Additional Documentation
 
 Additional documentation is available on [GitHub](https://github.com/wazzamatazz/cake-recipes).

--- a/src/Jaahas.Cake.Extensions/content/build-state.cake
+++ b/src/Jaahas.Cake.Extensions/content/build-state.cake
@@ -52,6 +52,9 @@ public class BuildState {
     // MSBuild Version property value.
     public string PackageVersion { get; set; }
 
+    // Projects to build container images for when the PublishContainer target is run.
+    public IEnumerable<string> PublishContainerProjects { get; set; }
+
     // Additional MSBuild properties.
     public ICollection<string> MSBuildProperties { get; set; }
 

--- a/src/Jaahas.Cake.Extensions/content/task-definitions.cake
+++ b/src/Jaahas.Cake.Extensions/content/task-definitions.cake
@@ -11,6 +11,10 @@ public readonly struct TaskDefinitions {
 
     public CakeTaskBuilder Pack { get; init; }
 
+    public CakeTaskBuilder Publish { get; init; }
+
+    public CakeTaskBuilder PublishContainer { get; init; }
+
     public CakeTaskBuilder BillOfMaterials { get; init; }
 
 }


### PR DESCRIPTION
This PR adds `Publish` and `PublishContainer` targets.

When the `Publish` target is run, it will iterate over all project files (files matching `*.*proj`) in the repository. For each project, it then searches for `*.pubxml` files anywhere in the project folder and subfolders. A `dotnet publish` command is executed for all publish profiles it finds for the project.

When the `PublishContainer` is run, it builds containers for each project that has been explicitly identified as a container project in the Cake script. Projects can be identified as container projects by specifying a value for the optional `containerProjects` argument when calling the `Bootstrap()` method in the Cake script:

```cake
Bootstrap(
    DefaultSolutionFile, 
    VersionFile, 
    containerProjects: new [] {
        "MyFirstContainerProject",
        "MySecondContainerProject"
    });
```

Additional changes include:
- The `Release` configuration is now used by default when the `Pack`, `Publish`, `PublishContainer` or `BillOfMaterials` target is specified and no `--configuration` argument has been passed to the Cake script.
- Specifying the `Pack`, `Publish`, `PublishContainer` or `BillOfMaterials` target will now automatically enable the `Clean` target.