### PR TITLE
Do not set NoRestore/NoBuild during publish

### DIFF
--- a/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
+++ b/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <Description>Extensions for the Cake build system.</Description>
-    <Version>2.1.0</Version>
+    <Version>2.2.1</Version>
     <Authors>Graham Watts</Authors>
     <CopyrightStartYear>2021</CopyrightStartYear>
     <PackageProjectUrl>https://github.com/wazzamatazz/cake-recipes</PackageProjectUrl>

--- a/src/Jaahas.Cake.Extensions/content/build-utilities.cake
+++ b/src/Jaahas.Cake.Extensions/content/build-utilities.cake
@@ -286,8 +286,6 @@ private void ConfigureTasks() {
 
                         var buildSettings = new DotNetPublishSettings {
                             Configuration = state.Configuration,
-                            NoRestore = true,
-                            NoBuild = false,
                             MSBuildSettings = new DotNetMSBuildSettings()
                         };
 


### PR DESCRIPTION
Modifies the Publish task so that it does not set the NoRestore or NoBuild parameters as this was preventing the target from creating trimmed assemblies for publish profiles that requested trimming.