### PR TITLE
Remove use of Cake.Git

### DIFF
--- a/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
+++ b/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <Description>Extensions for the Cake build system.</Description>
-    <Version>2.2.1</Version>
+    <Version>2.3.0</Version>
     <Authors>Graham Watts</Authors>
     <CopyrightStartYear>2021</CopyrightStartYear>
     <PackageProjectUrl>https://github.com/wazzamatazz/cake-recipes</PackageProjectUrl>


### PR DESCRIPTION
This PR removes the use of the Cake.Git add-in and instead calls `git` directly to get the name of the current branch.