### PR TITLE
Set default container architecture using OS architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Update your `build.cake` file as follows:
 const string DefaultSolutionFile = "./MySolution.sln";
 const string VersionFile = "./version.json";
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=2.1.0
+#load nuget:?package=Jaahas.Cake.Extensions&version=3.0.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);
@@ -55,7 +55,7 @@ The following command line arguments are supported by the recipe:
 | `--build-metadata=<METADATA>` | Additional build metadata that will be included in the information version number generated for compiled assemblies. | | |
 | `--container-registry=<REGISTRY>` | The container registry to publish images to when calling the `PublishContainer` target. | Local Docker or Podman registry. | Any valid registry address. Registry authentication is managed by Docker or Podman. See [here](https://github.com/dotnet/sdk-container-builds/blob/main/docs/RegistryAuthentication.md) for more information. |
 | `--container-os=<OS>` | The container operating system to target. | `linux` | Any valid [.NET runtime identifier](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) operating system. |
-| `--container-arch=<ARCHITECTURE>` | The container processor architecture to use. | `x64` | Any valid [.NET runtime identifier](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) processor architecture. |
+| `--container-arch=<ARCHITECTURE>` | The container processor architecture to use. | The architecture for the operating system. | Any valid [.NET runtime identifier](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) processor architecture. |
 | `--property=<PROPERTY>` | Specifies an additional property to pass to MSBuild. The value must be specified using a `<NAME>=<VALUE>` format e.g. `--property="NoWarn=CS1591"`. This argument can be specified multiple times. | | |
 | `--github-username=<USERNAME>` | Specifies the GitHub username to use when making authenticated API calls to GitHub while running the `BillOfMaterials` task. You must specify the `--github-token` argument as well when specifying this argument. | |
 | `--github-token=<PERSONAL ACCESS TOKEN>` | Specifies the GitHub personal access token to use when making authenticated API calls to GitHub while running the `BillOfMaterials` task. You must specify the `--github-username` argument as well when specifying this argument. | |

--- a/samples/.config/dotnet-tools.json
+++ b/samples/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
     "isRoot": true,
     "tools": {
       "cake.tool": {
-        "version": "4.0.0",
+        "version": "5.0.0",
         "commands": [
           "dotnet-cake"
         ]

--- a/samples/build.cake
+++ b/samples/build.cake
@@ -53,8 +53,9 @@ const string VersionFile = "./version.json";
 //     Default: linux
 //
 // --container-arch=<ARCHITECTURE>
-//   The container processor architecture to use when the PublishContainer target is run.
-//     Default: x64
+//   The container processor architecture to use when the PublishContainer target is run (e.g. 
+//   arm64, x64).
+//     Default: architecture for the current OS
 //
 // --property=<PROPERTY>
 //   Specifies an additional property to pass to MSBuild during Build and Pack targets. The value

--- a/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
+++ b/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <Description>Extensions for the Cake build system.</Description>
-    <Version>2.3.0</Version>
+    <Version>3.0.0</Version>
     <Authors>Graham Watts</Authors>
     <CopyrightStartYear>2021</CopyrightStartYear>
     <PackageProjectUrl>https://github.com/wazzamatazz/cake-recipes</PackageProjectUrl>

--- a/src/Jaahas.Cake.Extensions/README.md
+++ b/src/Jaahas.Cake.Extensions/README.md
@@ -30,6 +30,30 @@ Bootstrap(DefaultSolutionFile, VersionFile);
 Run();
 ```
 
+# Command Line Arguments
+
+The following command line arguments are supported by the recipe:
+
+| Argument | Description | Default Value | Allowed Values |
+| -------- | ----------- | ------------- | ---------------|
+| `--branch=<FRIENDLY BRANCH NAME>` | The friendly name of the source control branch that is being built. Ignored for Git repositories. | | |
+| `--project=<PROJECT OR SOLUTION>` | The MSBuild project or solution to build. | `DefaultSolutionFile` constant in `build.cake` file | |
+| `--target=<TARGET>` | The Cake target to run. | `Test` | `Clean`, `Restore`, `Build`, `Test`, `Pack`, `Publish`, `PublishContainer`, `BillOfMaterials` |
+| `--configuration=<CONFIGURATION>` | The MSBuild configuration to use. | `Debug`; `Release` when the `Pack`, `Publish` or `PublishContainer` target is specified | Any configuration defined in the MSBuild solution |
+| `--clean` | Specifies that this is a rebuild rather than an incremental build. All artifact, bin, and test output folders will be cleaned prior to running the specified target. | | |
+| `--no-tests` | Specifies that unit tests should be skipped, even if a target that depends on the `Test` target is specified. | | |
+| `--ci` | Forces continuous integration build mode. Not required if the build is being run by a supported continuous integration build system. | | |
+| `--sign-output` | Tells MSBuild that signing is required by setting the 'SignOutput' build property to 'True'. The signing implementation must be supplied by MSBuild. | | |
+| `--build-counter=<COUNTER>` | The build counter. This is used when generating version numbers for the build. | -1 | |
+| `--build-metadata=<METADATA>` | Additional build metadata that will be included in the information version number generated for compiled assemblies. | | |
+| `--container-registry=<REGISTRY>` | The container registry to publish images to when calling the `PublishContainer` target. | Local Docker or Podman registry. | Any valid registry address. Registry authentication is managed by Docker or Podman. See [here](https://github.com/dotnet/sdk-container-builds/blob/main/docs/RegistryAuthentication.md) for more information. |
+| `--container-os=<OS>` | The container operating system to target. | `linux` | Any valid [.NET runtime identifier](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) operating system. |
+| `--container-arch=<ARCHITECTURE>` | The container processor architecture to use. | The architecture for the operating system. | Any valid [.NET runtime identifier](https://learn.microsoft.com/en-us/dotnet/core/rid-catalog) processor architecture. |
+| `--property=<PROPERTY>` | Specifies an additional property to pass to MSBuild. The value must be specified using a `<NAME>=<VALUE>` format e.g. `--property="NoWarn=CS1591"`. This argument can be specified multiple times. | | |
+| `--github-username=<USERNAME>` | Specifies the GitHub username to use when making authenticated API calls to GitHub while running the `BillOfMaterials` task. You must specify the `--github-token` argument as well when specifying this argument. | |
+| `--github-token=<PERSONAL ACCESS TOKEN>` | Specifies the GitHub personal access token to use when making authenticated API calls to GitHub while running the `BillOfMaterials` task. You must specify the `--github-username` argument as well when specifying this argument. | |
+
+
 # Targets
 
 The recipe supports the following targets (specified by the `--target` parameter passed to Cake):

--- a/src/Jaahas.Cake.Extensions/content/build-utilities.cake
+++ b/src/Jaahas.Cake.Extensions/content/build-utilities.cake
@@ -309,7 +309,7 @@ private void ConfigureTasks() {
 
                 var registry = Argument("container-registry", "");
                 var os = Argument("container-os", "linux");
-                var arch = Argument("container-arch", "x64");
+                var arch = Argument("container-arch", System.Runtime.InteropServices.RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant());
 
                 foreach (var projectFile in GetFiles("./**/*.*proj")) {
                     var projectDir = projectFile.GetDirectory();


### PR DESCRIPTION
This PR modifies the default value for the `--container-arch` argument to be the architecture for the host OS instead of being hard-coded to `x64`.