### PR TITLE
Bump CycloneDX tool and package version

### DIFF
--- a/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
+++ b/src/Jaahas.Cake.Extensions/Jaahas.Cake.Extensions.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <Description>Extensions for the Cake build system.</Description>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <Authors>Graham Watts</Authors>
     <CopyrightStartYear>2021</CopyrightStartYear>
     <PackageProjectUrl>https://github.com/wazzamatazz/cake-recipes</PackageProjectUrl>

--- a/src/Jaahas.Cake.Extensions/content/build-utilities.cake
+++ b/src/Jaahas.Cake.Extensions/content/build-utilities.cake
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 using Spectre.Console;
 
-#tool dotnet:?package=CycloneDX&version=5.0.1
+#tool dotnet:?package=CycloneDX&version=5.4.0
 
 #load "build-state.cake"
 #load "task-definitions.cake"


### PR DESCRIPTION
Updated CycloneDX tool version from 5.0.1 to 5.4.0 in build-utilities.cake and incremented Jaahas.Cake.Extensions package version to 5.0.1. This ensures compatibility with the latest CycloneDX features such as .slnx file support